### PR TITLE
Changed ConnectConfig to NewWithConfig since pgx/v5 made this breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func main() {
     return nil
   }
 
-  pgxConnPool, err := pgxpool.ConnectConfig(context.TODO(), pgxConfig)
+  pgxConnPool, err := pgxpool.NewWithConfig(context.TODO(), pgxConfig)
   if err != nil {
     panic(err)
   }


### PR DESCRIPTION
See https://go.libhunt.com/pgx-changelog/5.0.0 search for "pgxpool" and observe: "🚚 Connect and ConnectConfig have been renamed to New and NewWithConfig respectively."